### PR TITLE
⚙️ Deprecate sipairs, spairs and snext

### DIFF
--- a/luarules/Utilities/tablefunctions.lua
+++ b/luarules/Utilities/tablefunctions.lua
@@ -105,7 +105,7 @@ local function MakeRealTable(proxy, debugTag)
 	end
 	local proxyLocal = proxy
 	local ret = {}
-	for i,v in spairs(proxyLocal) do
+	for i,v in pairs(proxyLocal) do
 		if type(v) == "table" then
 			ret[i] = MakeRealTable(v)
 		else

--- a/luarules/gadgets/cmd_instaload.lua
+++ b/luarules/gadgets/cmd_instaload.lua
@@ -518,10 +518,8 @@ local spIsUnitInView = Spring.IsUnitInView
 local UItextColor = {1.0, 1.0, 0.6, 1.0}
 local UItextSize = 14.0
 
-local snext = snext
-
 --function gadget:DrawWorld()
---    if not snext(SYNCED.currentassignablecapacity) then
+--    if not next(SYNCED.currentassignablecapacity) then
 --        return --//no transports to draw
 --    end
 --

--- a/luarules/gadgets/unit_morph.lua
+++ b/luarules/gadgets/unit_morph.lua
@@ -1761,8 +1761,6 @@ else
 local gameFrame;
 local SYNCED = SYNCED
 local CallAsTeam = CallAsTeam
-local spairs = spairs
-local snext = snext
 
 local GetUnitTeam         = Spring.GetUnitTeam
 local GetUnitHeading      = Spring.GetUnitHeading
@@ -2030,7 +2028,7 @@ function gadget:Update()
   if (frame<=oldFrame) then
 	return end
   oldFrame = frame
-  if not SYNCED.morphUnits or (not snext(SYNCED.morphUnits)) then    -- If table empty, return
+  if not SYNCED.morphUnits or (not next(SYNCED.morphUnits)) then    -- If table empty, return
 	return end
   -- Script.LuaUI: makes an unsynced gadget call a function that is in a listening widget.
   local hasMorphUpdate = Script.LuaUI('MorphUpdate')
@@ -2046,7 +2044,7 @@ function gadget:Update()
 	  then readTeam = Script.ALL_ACCESS_TEAM
 	  else readTeam = GetLocalTeamID() end
 	CallAsTeam({ ['read'] = readTeam }, function()
-				for unitID, morphData in spairs(SYNCED.morphUnits) do
+				for unitID, morphData in pairs(SYNCED.morphUnits) do
 				  if (unitID and morphData)and(IsUnitVisible(unitID)) then
 					morphTable[unitID] = { progress=morphData.progress, into=morphData.def.into }
 				  end
@@ -2057,7 +2055,7 @@ function gadget:Update()
 end
 
 function gadget:DrawWorld()
-  if not SYNCED.morphUnits or (not snext(SYNCED.morphUnits)) then
+  if not SYNCED.morphUnits or (not next(SYNCED.morphUnits)) then
 	return --//no morphs to draw
   end
 
@@ -2089,7 +2087,7 @@ function gadget:DrawWorld()
   --- [END] Draw MorphQueue indexes
 
   CallAsTeam({ ['read'] = readTeam }, function()
-	for unitID, morphData in spairs(SYNCED.morphUnits) do
+	for unitID, morphData in pairs(SYNCED.morphUnits) do
 	  if unitID and morphData and IsUnitVisible(unitID) then
 		DrawMorphUnit(unitID, morphData, readTeam)
 	  end

--- a/luarules/system.lua
+++ b/luarules/system.lua
@@ -48,9 +48,9 @@ if (System == nil) then
     --  Unsynced Utilities
     --
     SYNCED  = SYNCED,
-    snext   = snext,
-    spairs  = spairs,
-    sipairs = sipairs,
+    snext   = next, -- the following 3 are deprecated, but defined in case any legacy code uses them
+    spairs  = pairs,
+    sipairs = ipairs,
     
     --
     --  Standard libraries


### PR DESCRIPTION
These are no longer needed and are the same as regular pairs etc. Left them defined in case there's legacy code (e.g. in maps or something) using them.