### PR TITLE
"Use" the built-in engine version check

### DIFF
--- a/common/springFunctions.lua
+++ b/common/springFunctions.lua
@@ -25,34 +25,6 @@ local utilities = {
 		local devUI = Spring.GetConfigInt('DevUI', 0)
 		return (devUI > 0) and true or false
 	end,
-	
-	-- Compares engine version to see if it is at least --e.g. 105.1.1-1392-g5fb0c97 BAR105
-	EngineVersionAtLeast = function (major,medor,minor,build)
-		-- split along dots
-		local v = Engine.versionFull
-		local dotsplit = string.split(Engine.versionFull,'.')
-		local dashsplit = string.split(dotsplit[3],'-')
-		local mymajor = tonumber(dotsplit[1]) --tonumber(string.sub(v, 1, string.find(v, '.',nil, true) -1))
-		local mymedor = tonumber(dotsplit[2])
-		local myminor = tonumber(dashsplit[1]) 
-		local mybuild = tonumber(dashsplit[2])
-		if major > mymajor 
-			then return true 
-		elseif major == mymajor then 
-			if mymedor > medor then 
-				return true 
-			elseif mymedor == medor then 
-				if myminor > minor then 
-					return true 
-				elseif myminor == minor then 
-					if mybuild >= build then 
-						return true
-					end
-				end
-			end
-		end
-		return false
-	end,
 
 	CustomKeyToUsefulTable = tableFunctions.CustomKeyToUsefulTable,
 }

--- a/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
+++ b/modelmaterials_gl4/templates/defaultMaterialTemplate.lua
@@ -1690,7 +1690,7 @@ local defaultMaterialTemplate = {
 	-- they need to be redefined on every child material that has its own {shader,deferred,shadow}Definitions
 	shaderDefinitions = {
 		"#define RENDERING_MODE 0",
-		"#define SKINSUPPORT 1", -- .. (Spring.Utilities.EngineVersionAtLeast(105,1,1,1653) and "1" or "0"),
+		"#define SKINSUPPORT 1", -- .. (Script.IsEngineMinVersion(105, 0, 1653) and "1" or "0"),
 		"#define SUNMULT pbrParams[6]",
 		"#define EXPOSURE pbrParams[7]",
 
@@ -1707,7 +1707,7 @@ local defaultMaterialTemplate = {
 	},
 	deferredDefinitions = {
 		"#define RENDERING_MODE 1",
-		"#define SKINSUPPORT 1", --.. (Spring.Utilities.EngineVersionAtLeast(105,1,1,1653) and "1" or "0"),
+		"#define SKINSUPPORT 1", --.. (Script.IsEngineMinVersion(105, 0, 1653) and "1" or "0"),
 		"#define SUNMULT pbrParams[6]",
 		"#define EXPOSURE pbrParams[7]",
 
@@ -1724,7 +1724,7 @@ local defaultMaterialTemplate = {
 	},
 	shadowDefinitions = {
 		"#define RENDERING_MODE 2",
-		"#define SKINSUPPORT 1", -- .. (Spring.Utilities.EngineVersionAtLeast(105,1,1,1653) and "1" or "0"),
+		"#define SKINSUPPORT 1", -- .. (Script.IsEngineMinVersion(105, 0, 1653) and "1" or "0"),
 		"#define SUPPORT_DEPTH_LAYOUT ".. tostring((Platform.glSupportFragDepthLayout and 1) or 0),
 		"#define SUPPORT_CLIP_CONTROL ".. tostring((Platform.glSupportClipSpaceControl and 1) or 0),
 		[[
@@ -1741,7 +1741,7 @@ local defaultMaterialTemplate = {
 	},
 	reflectionDefinitions = {
 		"#define RENDERING_MODE 0",
-		"#define SKINSUPPORT 1", -- .. (Spring.Utilities.EngineVersionAtLeast(105,1,1,1653) and "1" or "0"),
+		"#define SKINSUPPORT 1", -- .. (Script.IsEngineMinVersion(105, 0, 1653) and "1" or "0"),
 		"#define SUNMULT pbrParams[6]",
 		"#define EXPOSURE pbrParams[7]",
 


### PR DESCRIPTION
Engine knows better, no need to rely on string parsing hax.

It wasn't actually used, but I updated the commented out lines since they serve as a reminder that this function exists.

The engine requires the middle value to be zero at the moment, I am not sure why but it may well be a feature (since that value is always 1 in builds and is pretty much redundant).